### PR TITLE
Communication small fix and tweaks

### DIFF
--- a/docs/comm_protocol.md
+++ b/docs/comm_protocol.md
@@ -50,7 +50,7 @@ uint8_t identifier.
 
 | Name           | ID   | Data Length | Description                      |
 |----------------|------|-------------|----------------------------------|
-| GIMBAL_CMD_ID  | 0x00 | 12          | Movement of the gimbal           |
+| GIMBAL_CMD_ID  | 0x00 | 10          | Movement of the gimbal           |
 | COLOR_CMD_ID   | 0x01 | 1           | My color, red is 0 and blue is 1 |
 | CHASSIS_CMD_ID | 0x02 | 12          | Movement of the chassis          |
 


### PR DESCRIPTION
Fixed some bugs and modified some tests in minipc protocol

### Minor Changes
- Correct Gimbal packet size in doc
- Added latency test
- Instead of skipping packet header when seeing a bad packet, now skips minimum packet size
- check CMD_ID validity in `try_parse_one()`

### Minor Bug Found
https://github.com/illini-robomaster/iRM_Vision_2023/blob/58cecd1ad7f2aa5b4cd011619db59730cf203cef/Communication/communicator.py#L184-L186
- The program will only try parsing packet if the buffer size is larger than maximum possible packet size. Thus if receiving small packets, multiple packets has to be received before actually parsing them. For example if max size is 21 bytes and PC/Jetson is receiving packets of size 10 bytes, two packets will wait in the buffer. Only when a third packet is received, then the first packet will be parsed. This might not be a big issue when receiving packets at a high frequency (only some delay) but will cause problem when receiving a single packet.